### PR TITLE
fix(pages/Index.vue): fix can't select file in dialog

### DIFF
--- a/packages/renderer/src/pages/settings/Index.vue
+++ b/packages/renderer/src/pages/settings/Index.vue
@@ -284,7 +284,7 @@ export default {
           filePaths: [dirPath],
         } = await ipcRenderer.callMain('dialog:open', {
           title: 'Import data',
-          properties: ['openDirectory'],
+          properties: ['openFile'],
           filters: [{ name: 'JSON', extensions: ['json'] }],
         });
 


### PR DESCRIPTION
Using `openDirectory` will only directories can be selected, but `JSON` is a filetype. Finally, I can't choose anything when I open the dialog.

![图片](https://github.com/Daniele-rolli/Beaver-Notes/assets/26884666/dbd051bd-266f-4ea9-a877-53fc0273282a)
