### PR TITLE
change translation for interfacesize

### DIFF
--- a/packages/renderer/src/pages/settings/locales/de.json
+++ b/packages/renderer/src/pages/settings/locales/de.json
@@ -157,7 +157,7 @@
     "invaliddata": "Ungültige Daten",
     "syncreminder": "Verstecke Synchronisationserinnerung",
     "spellcheck": "Rechtschreibprüfung",
-    "interfacesize": "Interface-Größe",
+    "interfacesize": "Anzeigegröße",
     "large": "Groß",
     "medium": "Mittel",
     "default": "Standard",


### PR DESCRIPTION
Hi Daniele,

I have made a small change to your German translation. For me, the term "interface" is too technical and "display" fits better in context.

I really like the new features in the upcoming version.

Best regards
Danny