### PR TITLE
chore: ignore node_modules when packaging

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -11,6 +11,7 @@ const electronBuilderConfig = {
   },
   files: [
     'packages/**/dist/**',
+    '!node_modules/**/*',
   ],
   extraMetadata: {
     version: packageJSON.version,


### PR DESCRIPTION
There is no need to package `node_modules` after bundled. This configuration will ignore it and cut down our package size.