### PR TITLE
fix: use import instead of require

### DIFF
--- a/packages/main/src/index.js
+++ b/packages/main/src/index.js
@@ -9,7 +9,7 @@ import {
   Notification,
 } from 'electron';
 import windowStateKeeper from 'electron-window-state';
-const { localStorage } = require('electron-browser-storage');
+import * as browserStorage from 'electron-browser-storage';
 import { ipcMain } from 'electron-better-ipc';
 import path, { join, normalize } from 'path';
 import { URL } from 'url';
@@ -29,6 +29,8 @@ import deTranslations from '../../renderer/src/pages/settings/locales/de.json';
 import zhTranslations from '../../renderer/src/pages/settings/locales/zh.json';
 import nlTranslations from '../../renderer/src/pages/settings/locales/nl.json';
 import esTranslations from '../../renderer/src/pages/settings/locales/es.json';
+
+const { localStorage } = browserStorage;
 
 const isMac = process.platform === 'darwin';
 
@@ -96,7 +98,7 @@ const createWindow = async () => {
       ? env.VITE_DEV_SERVER_URL
       : new URL(
           '../renderer/dist/index.html',
-          'file://' + __dirname
+          'file://' + __dirname,
         ).toString();
 
   await mainWindow.loadURL(pageUrl);
@@ -177,25 +179,25 @@ ipcMain.answerRenderer('app:set-zoom', (newZoomLevel) => {
 ipcMain.answerRenderer('app:get-zoom', () => mainWindow.webContents.zoomFactor);
 
 ipcMain.answerRenderer('app:change-menu-visibility', (visibility, win) =>
-  win.setMenuBarVisibility(visibility)
+  win.setMenuBarVisibility(visibility),
 );
 
 ipcMain.answerRenderer('dialog:open', (props) => dialog.showOpenDialog(props));
 ipcMain.answerRenderer('dialog:message', (props) =>
-  dialog.showMessageBox(props)
+  dialog.showMessageBox(props),
 );
 ipcMain.answerRenderer('dialog:save', (props) => dialog.showSaveDialog(props));
 
 ipcMain.answerRenderer('fs:copy', ({ path, dest }) => copy(path, dest));
 ipcMain.answerRenderer('fs:output-json', ({ path, data }) =>
-  outputJson(path, data)
+  outputJson(path, data),
 );
 ipcMain.answerRenderer('fs:read-json', (path) => readJson(path));
 ipcMain.answerRenderer('fs:ensureDir', (path) => ensureDir(path));
 ipcMain.answerRenderer('fs:pathExists', (path) => pathExistsSync(path));
 ipcMain.answerRenderer('fs:remove', (path) => remove(path));
 ipcMain.answerRenderer('fs:writeFile', ({ path, data }) =>
-  writeFileSync(path, data)
+  writeFileSync(path, data),
 );
 ipcMain.answerRenderer('helper:relaunch', (options = {}) => {
   app.relaunch({
@@ -207,22 +209,22 @@ ipcMain.answerRenderer('helper:relaunch', (options = {}) => {
 ipcMain.answerRenderer('helper:get-path', (name) => app.getPath(name));
 ipcMain.answerRenderer(
   'helper:is-dark-theme',
-  () => nativeTheme.shouldUseDarkColors
+  () => nativeTheme.shouldUseDarkColors,
 );
 
 ipcMain.answerRenderer('storage:store', (name) => store[name]?.store);
 ipcMain.answerRenderer(
   'storage:replace',
-  ({ name, data }) => (store[name].store = data)
+  ({ name, data }) => (store[name].store = data),
 );
 ipcMain.answerRenderer('storage:get', ({ name, key, def }) =>
-  store[name]?.get(key, def)
+  store[name]?.get(key, def),
 );
 ipcMain.answerRenderer('storage:set', ({ name, key, value }) =>
-  store[name]?.set(key, value)
+  store[name]?.set(key, value),
 );
 ipcMain.answerRenderer('storage:delete', ({ name, key }) =>
-  store[name]?.delete(key)
+  store[name]?.delete(key),
 );
 ipcMain.answerRenderer('storage:has', ({ name, key }) => store[name]?.has(key));
 ipcMain.answerRenderer('storage:clear', (name) => store[name]?.clear());
@@ -354,7 +356,7 @@ function initializeMenu() {
           click: async () => {
             const { shell } = require('electron');
             await shell.openExternal(
-              'https://danieles-organization.gitbook.io/beaver-notes'
+              'https://danieles-organization.gitbook.io/beaver-notes',
             );
           },
         },


### PR DESCRIPTION
Well, Vite does not support `require()` by default. If you want to use `require()`, I recommend you to use [this plugin](https://github.com/wangzongming/vite-plugin-require). But most of time, `import` is enough to handle all.