### PR TITLE
Update electron-builder.config.cjs

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -115,8 +115,5 @@ const electronBuilderConfig = {
   },
 };
 
-module.exports = async () => {
-  const envModule = await import('./env.js');
-  envModule.loadEnv('private');
-  return electronBuilderConfig;
-};
+require('./env.js').loadEnv('private');
+module.exports = electronBuilderConfig;


### PR DESCRIPTION
Fix electron-builder crash on Windows by removing dynamic ESM import from CJS config